### PR TITLE
Clarify _get_json docstring

### DIFF
--- a/fundamentals/screener.py
+++ b/fundamentals/screener.py
@@ -45,7 +45,11 @@ def _canon_for_mx(sym: str) -> str:
     return sym.upper().strip()
 
 def _get_json(url: str, params: Optional[dict] = None, timeout: int = 15, retries: int = 2) -> Optional[dict | list]:
-    """GET with small retry/backoff for 429/5xx."""
+    """
+    GET with small retry/backoff for 429/5xx.
+
+    Retries on request exceptions and returns ``None`` for any non-OK response.
+    """
     backoff = 0.6
     for i in range(retries + 1):
         try:


### PR DESCRIPTION
## Summary
- Clarify _get_json docstring to cover retries and return values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bfe04faa88330888d7e9717de4d76