### PR TITLE
Fix execution summary counts when sanity checks drop all rows

### DIFF
--- a/execution/engine.py
+++ b/execution/engine.py
@@ -113,7 +113,10 @@ def execute_today(csv_path: Path | None = None, sleep_between: float = 0.20) -> 
         print("\n— Execution summary —")
         print(f"Signals in file: {orig_rows}")
         print(f"After de-dup:   {dedup_rows} (dropped {dropped_dupes})")
-        print(f"After open flt: 0 (dropped {dedup_rows})")
+        # Preserve counts from the open-orders/positions filter so the
+        # summary reflects what actually happened before the sanity checks
+        # removed all remaining rows.
+        print(f"After open flt: {filtered_rows} (dropped {dropped_open})")
         print(f"Placed: 0 | Skipped BP: 0 | Failed: 0")
         return
 

--- a/tests/test_engine_empty_summary.py
+++ b/tests/test_engine_empty_summary.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+
+class DummyAPI:
+    def list_positions(self):
+        return []
+
+    def list_orders(self, *args, **kwargs):
+        return []
+
+
+def test_summary_counts_after_sanity_check(monkeypatch, tmp_path, capsys):
+    # Provide dummy API credentials before importing the module
+    monkeypatch.setenv("ALPACA_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_API_SECRET", "secret")
+
+    # Ensure repository root is on sys.path then import the function
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from execution.engine import execute_today
+
+    # Create CSV with a row that will be dropped by sanity checks (qty <= 0)
+    csv_path = tmp_path / "trade_signals.csv"
+    df = pd.DataFrame({
+        "symbol": ["AAPL"],
+        "direction": ["buy"],
+        "quantity": [0],  # invalid quantity -> triggers empty after sanity checks
+        "target": [150],
+        "stop": [140],
+    })
+    df.to_csv(csv_path, index=False)
+
+    # Patch API to avoid external calls
+    monkeypatch.setattr("execution.engine.api", DummyAPI())
+
+    execute_today(csv_path=csv_path)
+
+    out = capsys.readouterr().out
+    assert "After open flt: 1 (dropped 0)" in out


### PR DESCRIPTION
## Summary
- Fix early-return summary in `execute_today` to report filtered rows and dropped-open counts instead of hard-coded values
- Add regression test covering empty-data path and verifying summary counts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bfe02bd708330bffd792e3b831139