### PR TITLE
Handle varied trade signal headers

### DIFF
--- a/execution/engine.py
+++ b/execution/engine.py
@@ -30,6 +30,18 @@ _COLUMN_ALIASES = {
 }
 
 def _normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of *df* with normalized column names.
+
+    The incoming CSVs may use various casings or spaces in the header
+    (e.g. ``Qty`` or ``Take Profit``).  The previous implementation only
+    handled exact lowercase matches, which meant these common variants were
+    left untouched and later validation failed.  We now standardize headers by
+    stripping whitespace, lowercasing, and replacing spaces with underscores
+    before applying the alias map.
+    """
+    df = df.copy()
+    df.columns = [c.strip().lower().replace(" ", "_") for c in df.columns]
+
     col_map = {}
     for k, v in _COLUMN_ALIASES.items():
         if k in df.columns and v not in df.columns:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,30 @@
+import os
+import importlib
+import sys
+from pathlib import Path
+import pandas as pd
+
+
+def test_normalize_columns_case_and_spaces(monkeypatch):
+    # Ensure broker.alpaca can import without real credentials
+    monkeypatch.setenv("ALPACA_API_KEY", "x")
+    monkeypatch.setenv("ALPACA_API_SECRET", "y")
+
+    # Ensure repository root on sys.path then import
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    engine = importlib.reload(importlib.import_module("execution.engine"))
+
+    df = pd.DataFrame({
+        "Qty": [1],
+        "Take Profit": [10],
+        "Stop Loss": [9],
+        "Side": ["buy"],
+        "Symbol": ["AAPL"],
+    })
+
+    norm = engine._normalize_columns(df)
+    engine._require_columns(norm, ["symbol", "direction", "quantity", "target", "stop"])
+
+    assert set(norm.columns) >= {"symbol", "direction", "quantity", "target", "stop"}


### PR DESCRIPTION
## Summary
- Normalize trade signal CSV headers by stripping whitespace, lowercasing, and replacing spaces before applying alias mapping
- Add regression test for column normalization with mixed-case headers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bfb800f508330bb5e187bf0a9947e